### PR TITLE
fix crash on Windows; add version embedding

### DIFF
--- a/crates/spin-python-engine/Cargo.toml
+++ b/crates/spin-python-engine/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = [ "cdylib" ]
 anyhow = "1"
 bytes = { version = "1.2.1", features = ["serde"] }
 http = "0.2"
-spin-sdk = { git = "https://github.com/fermyon/spin" }
+spin-sdk = { git = "https://github.com/fermyon/spin", default-features = false }
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "dde4694aaa6acf9370206527a798ac4ba6a8c5b8" }
 pyo3 = { version = "0.17.3", features = [ "abi3-py310" ] }
 once_cell = "1.16.0"

--- a/crates/spin-python-engine/src/lib.rs
+++ b/crates/spin-python-engine/src/lib.rs
@@ -24,6 +24,9 @@ thread_local! {
     static ENVIRON: OnceCell<Py<PyMapping>> = OnceCell::new();
 }
 
+#[export_name = "spin-sdk-language-python"]
+extern "C" fn __spin_sdk_language() {}
+
 fn bytes(py: Python<'_>, src: &[u8]) -> PyResult<Py<PyBytes>> {
     Ok(PyBytes::new_with(py, src.len(), |dst| {
         dst.copy_from_slice(src);


### PR DESCRIPTION
This fixes an issue causing `wizer` to fail due to `CPython` calling `fd_filestat_get` on stdio descriptors, which causes Wasmtime's WASI implementation to trap if those descriptors don't point to actual files.

This also updates the `spin-sdk` dependency to allow version embedding per
https://github.com/fermyon/spin/blob/main/docs/content/sips/011-component-versioning.md.