### PR TITLE
update to CPython 3.11.4 and Wizer 3.0.0

### DIFF
--- a/crates/spin-python-cli/Cargo.toml
+++ b/crates/spin-python-cli/Cargo.toml
@@ -14,10 +14,10 @@ anyhow = "1.0.68"
 clap = { version = "4.1.4", features = [ "derive" ] }
 tar = "0.4.38"
 tempfile = "3.3.0"
-wizer = "1.6.0"
-zstd = "0.10.0"
+wizer = "3.0.0"
+zstd = "0.11.1"
 
 [build-dependencies]
 anyhow = "1.0.68"
 tar = "0.4.38"
-zstd = "0.10.0"
+zstd = "0.11.1"


### PR DESCRIPTION
This addresses recent breakage which seems to be related to newer `rustc` versions combined with older `wasmtime` versions not playing nice together.  The CPython upgrade probably isn't neccessary, but I figure we should use the latest 3.11.x release anyway.