### PR TITLE
chore(*): manifest v2 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ spin plugins install --url https://github.com/fermyon/spin-python-sdk/releases/d
  
 ## Running Examples
 
-After installing the plugin, you can run the examples found in this repo:
+After installing the plugin, you can run the examples found in this repo.
+
+__Note__: These examples track Spin's `main` branch, so you may need to ensure you are using the [canary](https://github.com/fermyon/spin/releases/tag/canary) Spin release.  See https://developer.fermyon.com/spin/install.
+
+
 
 ```bash
 cd examples/hello world

--- a/examples/KV/spin.toml
+++ b/examples/KV/spin.toml
@@ -1,16 +1,18 @@
-spin_manifest_version = "1"
+spin_manifest_version = 2
+
+[application]
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 description = "Spin Python SDK KV"
-name = "spin-py-KV"
-trigger = { type = "http", base = "/" }
+name = "spin-py-kv"
 version = "0.1.0"
 
-[[component]]
-id = "python-sdk-example"
+[[trigger.http]]
+route = "/..."
+component = "py-kv"
+
+[component.py-kv]
 source = "app.wasm"
 key_value_stores = ["default"]
-[component.trigger]
-route = "/..."
-[component.build]
+[component.py-kv.build]
 command = "spin py2wasm app -o app.wasm"
 watch = ["app.py"]

--- a/examples/external_lib/spin.toml
+++ b/examples/external_lib/spin.toml
@@ -1,15 +1,17 @@
-spin_manifest_version = "1"
+spin_manifest_version = 2
+
+[application]
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 description = "Spin Python SDK example using external library"
 name = "spin-py-external-library"
-trigger = { type = "http", base = "/" }
 version = "0.1.0"
 
-[[component]]
-id = "python-sdk-example"
-source = "app.wasm"
-[component.trigger]
+[[trigger.http]]
 route = "/..."
-[component.build]
+component = "py-external-lib"
+
+[component.py-external-lib]
+source = "app.wasm"
+[component.py-external-lib.build]
 command = "spin py2wasm app -o app.wasm"
 watch = ["app.py", "Pipfile*"]

--- a/examples/hello_world/spin.toml
+++ b/examples/hello_world/spin.toml
@@ -1,15 +1,17 @@
-spin_manifest_version = "1"
+spin_manifest_version = 2
+
+[application]
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 description = "Spin Python SDK hello world"
 name = "spin-py-hello-world"
-trigger = { type = "http", base = "/" }
 version = "0.1.0"
 
-[[component]]
-id = "python-sdk-example"
-source = "app.wasm"
-[component.trigger]
+[[trigger.http]]
 route = "/..."
-[component.build]
+component = "python-sdk-example"
+
+[component.python-sdk-example]
+source = "app.wasm"
+[component.python-sdk-example.build]
 command = "spin py2wasm app -o app.wasm"
 watch = ["app.py"]

--- a/examples/llm/spin.toml
+++ b/examples/llm/spin.toml
@@ -1,16 +1,18 @@
-spin_manifest_version = "1"
+spin_manifest_version = 2
+
+[application]
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 description = "Spin Python SDK hello llm"
 name = "spin-py-hello-llm"
-trigger = { type = "http", base = "/" }
 version = "0.1.0"
 
-[[component]]
-id = "python-sdk-example"
+[[trigger.http]]
+route = "/..."
+component = "py-hello-llm"
+
+[component.py-hello-llm]
 source = "app.wasm"
 ai_models = ["llama2-chat", "all-minilm-l6-v2"]
-[component.trigger]
-route = "/..."
-[component.build]
+[component.py-hello-llm.build]
 command = "spin py2wasm app -o app.wasm"
 watch = ["app.py"]

--- a/examples/outbound_http/app.py
+++ b/examples/outbound_http/app.py
@@ -4,8 +4,8 @@ from spin_http import Request, Response, http_send
 def handle_request(request):
 
     response = http_send(
-        Request("GET", "https://some-random-api.ml/facts/dog", {}, None))
+        Request("GET", "https://random-data-api.fermyon.app/physics/json", {}, None))
 
     return Response(200,
                     {"content-type": "text/plain"},
-                    bytes(f"Here is a dog fact: {str(response.body, 'utf-8')}", "utf-8"))
+                    bytes(f"Here is a physics fact: {str(response.body, 'utf-8')}", "utf-8"))

--- a/examples/outbound_http/spin.toml
+++ b/examples/outbound_http/spin.toml
@@ -1,17 +1,19 @@
-spin_manifest_version = "1"
+spin_manifest_version = 2
+
+[application]
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 description = "Spin Python Outbound HTTP Example"
 name = "Spin-python-outbound-http"
-trigger = { type = "http", base = "/" }
 version = "0.1.0"
 
-[[component]]
-id = "python-sdk-example"
+[[trigger.http]]
+route = "/..."
+component = "python-outbound-http"
+
+[component.python-outbound-http]
 source = "app.wasm"
 environment = { hello = "teapot" }
-allowed_http_hosts = ["https://some-random-api.ml"]
-[component.trigger]
-route = "/..."
-[component.build]
+allowed_http_hosts = ["random-data-api.fermyon.app"]
+[component.python-outbound-http.build]
 command = "spin py2wasm app -o app.wasm"
 watch = ["app.py"]

--- a/examples/outbound_redis/spin.toml
+++ b/examples/outbound_redis/spin.toml
@@ -1,16 +1,18 @@
-spin_manifest_version = "1"
+spin_manifest_version = 2
+
+[application]
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 description = "Spin Python Outbound Redis example"
 name = "spin-python-outbound-redis"
-trigger = { type = "http", base = "/" }
 version = "0.1.0"
 
-[[component]]
-id = "python-sdk-outbound-redis"
-config = { redis_address = "redis://127.0.0.1:6379" }
-source = "app.wasm"
-[component.trigger]
+[[trigger.http]]
 route = "/..."
-[component.build]
+component = "python-sdk-outbound-redis"
+
+[component.python-sdk-outbound-redis]
+variables = { redis_address = "redis://127.0.0.1:6379" }
+source = "app.wasm"
+[component.python-sdk-outbound-redis.build]
 command = "spin py2wasm app -o app.wasm"
 watch = ["app.py"]

--- a/examples/sqlite/README.md
+++ b/examples/sqlite/README.md
@@ -1,3 +1,11 @@
 # Spin python sqlite
 
 A simple example showcasing the return of a simple response to a request that uses the SQLite funtionality of the Python SDK.
+
+## Build and run
+
+You'll need to apply the sql migration when you run this example:
+
+```console
+spin build --sqlite @migration.sql --up
+```

--- a/examples/sqlite/spin.toml
+++ b/examples/sqlite/spin.toml
@@ -1,16 +1,18 @@
-spin_manifest_version = "1"
+spin_manifest_version = 2
+
+[application]
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 description = "Spin Python SDK sqlite example"
 name = "spin-py-sqlite"
-trigger = { type = "http", base = "/" }
 version = "0.1.0"
 
-[[component]]
-id = "python-sdk-example"
+[[trigger.http]]
+route = "/..."
+component = "py-sqlite"
+
+[component.py-sqlite]
 source = "app.wasm"
 sqlite_databases = ["default"]
-[component.trigger]
-route = "/..."
-[component.build]
+[component.py-sqlite.build]
 command = "spin py2wasm app -o app.wasm"
 watch = ["app.py"]

--- a/templates/http-py/content/spin.toml
+++ b/templates/http-py/content/spin.toml
@@ -1,15 +1,17 @@
-spin_manifest_version = "1"
+spin_manifest_version = 2
+
+[application]
 authors = ["{{authors}}"]
 description = "{{project-description}}"
 name = "{{project-name}}"
-trigger = { type = "http", base = "{{http-base}}" }
 version = "0.1.0"
 
-[[component]]
-id = "{{project-name | kebab_case}}"
-source = "app.wasm"
-[component.trigger]
+[[trigger.http]]
 route = "{{http-path}}"
-[component.build]
+component = "{{project-name | kebab_case}}"
+
+[component.{{project-name | kebab_case}}]
+source = "app.wasm"
+[component.{{project-name | kebab_case}}.build]
 command = "spin py2wasm app -o app.wasm"
 watch = ["app.py", "Pipfile"]

--- a/templates/http-py/metadata/snippets/component.txt
+++ b/templates/http-py/metadata/snippets/component.txt
@@ -1,9 +1,10 @@
-[[component]]
-id = "{{project-name | kebab_case}}"
-source = "{{ output-path }}/app.wasm"
-[component.trigger]
+[[trigger.http]]
 route = "{{http-path}}"
-[component.build]
+component = "{{project-name | kebab_case}}"
+
+[component.{{project-name | kebab_case}}]
+source = "{{ output-path }}/app.wasm"
+[component.{{project-name | kebab_case}}.build]
 command = "spin py2wasm app -o app.wasm"
 workdir = "{{ output-path }}"
 watch = ["app.py", "Pipfile"]

--- a/templates/http-py/metadata/spin-template.toml
+++ b/templates/http-py/metadata/spin-template.toml
@@ -5,11 +5,9 @@ tags = ["http", "python", "py"]
 
 [add_component]
 skip_files = ["spin.toml"]
-skip_parameters = ["http-base"]
 [add_component.snippets]
 component = "component.txt"
 
 [parameters]
 project-description = { type = "string",  prompt = "Description", default = "" }
-http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }
 http-path = { type = "string", prompt = "HTTP path", default = "/...", pattern = "^/\\S*$" }

--- a/test/test-app/spin.toml
+++ b/test/test-app/spin.toml
@@ -1,18 +1,20 @@
-spin_version = "1"
+spin_manifest_version = 2
+
+[application]
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 description = "Spin Python SDK example"
 name = "python-sdk-example"
-trigger = { type = "http", base = "/" }
 version = "0.1.0"
 
-[[component]]
-id = "python-sdk-example"
+[[trigger.http]]
+route = "/..."
+component = "python-sdk-example"
+
+[component.python-sdk-example]
 environment = { hello = "teapot" }
-config = { redis_address = "redis://127.0.0.1:6379" }
+variables = { redis_address = "redis://127.0.0.1:6379" }
 files = [{ source = "static-assets/", destination = "/" }]
 source = "app.wasm"
 allowed_http_hosts = ["insecure:allow-all"]
-[component.trigger]
-route = "/..."
-[component.build]
+[component.python-sdk-example.build]
 command = "../../target/release/spin-python app -o app.wasm"


### PR DESCRIPTION
Updates apps under `examples`, `templates` and `test` to use the Spin manifest v2 syntax.

~~This should wait to be merged until the Spin 2.0 release is out.~~ This can be merged when ready after adding the following disclaimer: [docs(README.md): add note re: Spin canary](https://github.com/fermyon/spin-python-sdk/pull/57/commits/99e8ce8cef504117d629417c8f1c828f439b1572)