### PR TITLE
Some tests and docs expect a template on main

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 This is an SDK for creating [Spin](https://github.com/fermyon/spin) apps using Python.
 
-Note that this SDK supercedes an earlier, experimental version, which may be
+Note that this SDK supersedes an earlier, experimental version, which may be
 found in the [old-sdk](https://github.com/fermyon/spin-python-sdk/tree/old-sdk)
-branch.
+branch. _(The old template remains on `main` temporarily to preserve compatibility for some
+inbound linkes; it will be removed or replaced.)_
 
 ## [API Documentation](https://fermyon.github.io/spin-python-sdk/index.html)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is an SDK for creating [Spin](https://github.com/fermyon/spin) apps using P
 Note that this SDK supersedes an earlier, experimental version, which may be
 found in the [old-sdk](https://github.com/fermyon/spin-python-sdk/tree/old-sdk)
 branch. _(The old template remains on `main` temporarily to preserve compatibility for some
-inbound linkes; it will be removed or replaced.)_
+inbound links; it will be removed or replaced.)_
 
 ## [API Documentation](https://fermyon.github.io/spin-python-sdk/index.html)
 

--- a/templates/http-py/content/.gitignore
+++ b/templates/http-py/content/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+*.wasm
+.spin

--- a/templates/http-py/content/Pipfile
+++ b/templates/http-py/content/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+
+[requires]
+python_version = "3.10"

--- a/templates/http-py/content/README.md
+++ b/templates/http-py/content/README.md
@@ -1,0 +1,1 @@
+# A simple Spin HTTP component in Python

--- a/templates/http-py/content/app.py
+++ b/templates/http-py/content/app.py
@@ -1,0 +1,8 @@
+from spin_http import Response
+
+
+def handle_request(request):
+
+    return Response(200,
+                    {"content-type": "text/plain"},
+                    bytes(f"Hello from the Python SDK", "utf-8"))

--- a/templates/http-py/content/spin.toml
+++ b/templates/http-py/content/spin.toml
@@ -1,0 +1,15 @@
+spin_manifest_version = "1"
+authors = ["{{authors}}"]
+description = "{{project-description}}"
+name = "{{project-name}}"
+trigger = { type = "http", base = "{{http-base}}" }
+version = "0.1.0"
+
+[[component]]
+id = "{{project-name | kebab_case}}"
+source = "app.wasm"
+[component.trigger]
+route = "{{http-path}}"
+[component.build]
+command = "spin py2wasm app -o app.wasm"
+watch = ["app.py", "Pipfile"]

--- a/templates/http-py/metadata/snippets/component.txt
+++ b/templates/http-py/metadata/snippets/component.txt
@@ -1,0 +1,9 @@
+[[component]]
+id = "{{project-name | kebab_case}}"
+source = "{{ output-path }}/app.wasm"
+[component.trigger]
+route = "{{http-path}}"
+[component.build]
+command = "spin py2wasm app -o app.wasm"
+workdir = "{{ output-path }}"
+watch = ["app.py", "Pipfile"]

--- a/templates/http-py/metadata/spin-template.toml
+++ b/templates/http-py/metadata/spin-template.toml
@@ -1,0 +1,15 @@
+manifest_version = "1"
+id = "http-py"
+description = "HTTP request handler using Python"
+tags = ["http", "python", "py"]
+
+[add_component]
+skip_files = ["spin.toml"]
+skip_parameters = ["http-base"]
+[add_component.snippets]
+component = "component.txt"
+
+[parameters]
+project-description = { type = "string",  prompt = "Description", default = "" }
+http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }
+http-path = { type = "string", prompt = "HTTP path", default = "/...", pattern = "^/\\S*$" }


### PR DESCRIPTION
Spin e2e tests are currently failing because they expect to find a template on main (because the SUT Spin doesn't match any template tag).  Some docs also guide users to expect to find a template here (although the tags will satisfy users on releases who simply run `spin templates install`)  This temporarily places the `py2wasm`/SDK1 template on main to cover for while we create a `componentize-py` / SDK2.

(If we have a new template ready to go then that's a better solution than this.)
