### PR TITLE
update examples/matrix-math/README.md

### DIFF
--- a/examples/matrix-math/README.md
+++ b/examples/matrix-math/README.md
@@ -11,7 +11,6 @@ Python package containing native extensions within a guest component.
 
 * A clone of the Git repo in which you found this example
 * `spin` 2.2 or later
-    * As of this writing Spin 2.2 has not yet been released, so we must use the `main` branch of Spin for the time being. You can find pre-built binaries [here](https://github.com/fermyon/spin/releases/tag/canary).
 * `componentize-py` 0.11.2
 * `NumPy`, built for WASI
 


### PR DESCRIPTION
Remove obsolete note about Spin 2.2 not yet being released.