### PR TITLE
return result of future from `run_until_complete`

### DIFF
--- a/src/spin_sdk/http/poll_loop.py
+++ b/src/spin_sdk/http/poll_loop.py
@@ -152,7 +152,7 @@ class PollLoop(asyncio.AbstractEventLoop):
             if self.exception is not None:
                 raise self.exception
             
-        future.result()
+        return future.result()
 
     def is_running(self):
         return self.running


### PR DESCRIPTION
This mirrors the fix in https://github.com/bytecodealliance/componentize-py/pull/73