### PR TITLE
fix outbound request body streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ Finally, you can test your app using e.g. `curl` in another terminal:
 curl -i http://127.0.0.1:3000
 ```
 
-If all goes well, you should see:
+If all goes well, you should see something like:
 
 ```
 HTTP/1.1 200 OK
 content-type: text/plain
-transfer-encoding: chunked
-date: Tue, 09 Jan 2024 18:26:52 GMT
+content-length: 18
+date: Thu, 11 Apr 2024 17:42:31 GMT
 
 Hello from Python!
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spin-sdk"
-version = "3.1.0"
+version = "3.2.0"
 description = "Experimental SDK for Spin and Componentize-Py"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/spin_sdk/http/__init__.py
+++ b/src/spin_sdk/http/__init__.py
@@ -184,10 +184,8 @@ async def send_async(request: Request) -> Response:
     sink = Sink(outgoing_request.body())
     incoming_response: IncomingResponse = (await asyncio.gather(
         poll_loop.send(outgoing_request),
-        sink.send(outgoing_body)
+        send_and_close(sink, outgoing_body)
     ))[0]
-
-    sink.close()
 
     response_body = Stream(incoming_response.consume())
     body = bytearray()
@@ -207,3 +205,6 @@ async def send_async(request: Request) -> Response:
         else:
             body += chunk
 
+async def send_and_close(sink: Sink, data: bytes):
+    await sink.send(data)
+    sink.close()


### PR DESCRIPTION
There was a subtle issue in `spin_sdk.http.send_async` which caused deadlock when sending a request to a server that waits for the full request body before sending any part of a response.  Specifically, we must close the `Sink` as soon as we've written the whole body in order to communicate that there will be no further bytes.  Previously, we only closed the `Sink` after we'd started receiving the response, which can lead to deadlock.

This also bumps the package version to 3.2.0 and makes a minor README.md correction.