### PR TITLE
fix "resource has children" error in `spin_sdk.http.send`

### DIFF
--- a/src/spin_sdk/http/__init__.py
+++ b/src/spin_sdk/http/__init__.py
@@ -163,14 +163,14 @@ async def send_async(request: Request) -> Response:
     url_parsed = parse.urlparse(request.uri)
 
     match url_parsed.scheme:
-            case "http":
-                scheme: Scheme = Scheme_Http()
-            case "https":
-                scheme = Scheme_Https()
-            case "":
-                scheme = Scheme_Http()
-            case _:
-                scheme = Scheme_Other(url_parsed.scheme)
+        case "http":
+            scheme: Scheme = Scheme_Http()
+        case "https":
+            scheme = Scheme_Https()
+        case "":
+            scheme = Scheme_Http()
+        case _:
+            scheme = Scheme_Other(url_parsed.scheme)
 
     headers_dict = request.headers
 
@@ -218,14 +218,16 @@ async def send_async(request: Request) -> Response:
     while True:
         chunk = await response_body.next()
         if chunk is None:
+            headers = incoming_response.headers()
             simple_response = Response(
                 incoming_response.status(),
                 dict(map(
                     lambda pair: (pair[0], str(pair[1], "utf-8")),
-                    incoming_response.headers().entries()
+                    headers.entries()
                 )),
                 bytes(body)
             )
+            headers.__exit__(None, None, None)
             incoming_response.__exit__(None, None, None)
             return simple_response
         else:


### PR DESCRIPTION
We were neglecting to drop the resource returned by `incoming-response.headers` prior to dropping the `incoming-response` itself.  Either I'm crazy and this never worked or `wasmtime-wasi` wasn't enforcing this parent-child relationship last time I tested it.  Either way, this points to an urgent need for CI test coverage.