### PR TITLE
fix(docs): correct redis-trigger README title and fix typo

### DIFF
--- a/examples/external-lib-example/README.md
+++ b/examples/external-lib-example/README.md
@@ -17,7 +17,7 @@ Install the required packages specified in the `requirements.txt` using the comm
 pip3 install -r requirements.txt
 ```
 
-The above install all the required packages which includes the `http-router` pacakge.
+The above install all the required packages which includes the `http-router` package.
 
 ## Building and Running the Examples
 

--- a/examples/redis-trigger/README.md
+++ b/examples/redis-trigger/README.md
@@ -1,6 +1,6 @@
-# Example: External Library
+# Example: Redis Trigger
 
-This is an example showcasing the use of an external library [`http-router`](https://pypi.org/project/http-router/) within a guest component. 
+This is an example showcasing the use of a Redis trigger within a guest component. 
 
 ## Preparing the Environment
 


### PR DESCRIPTION
Fixes #127

- Fix redis-trigger README title (was "External Library")
- Fix "pacakge" typo in external-lib-example README
