### PR TITLE
chore(pyproject.toml): update to use license-files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "spin-sdk"
 version = "4.0.0"
 description = "Python SDK for Spin"
 readme = "README.md"
-license = { file = "LICENSE" }
+license-files = [ "LICENSE" ]
 authors = [ { name = "Spin Framework Contributors" } ]
 maintainers = [ { name = "Spin Framework Contributors" } ]
 keywords = [ "webassembly", "wasm", "component", "spin" ]


### PR DESCRIPTION
In recent CI runs (eg [on main](https://github.com/spinframework/spin-python-sdk/actions/runs/23903589531/job/69706322861)), I've noticed:

```
/tmp/build-env-yn8isllg/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2027-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  corresp(dist, value, root_dir)
```

Hence this PR, updating to use `license-files`.
