### PR TITLE
feat(postgres/sqlite): update API to be fully async

### DIFF
--- a/docs/v4/postgres.html
+++ b/docs/v4/postgres.html
@@ -43,36 +43,127 @@ el.replaceWith(d);
 <section>
 </section>
 <section>
-<h2 class="section-title" id="header-functions">Functions</h2>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
 <dl>
-<dt id="spin_sdk.postgres.open"><code class="name flex">
-<span>async def <span class="ident">open</span></span>(<span>connection_string: str) ‑> <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Connection" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Connection">Connection</a></span>
+<dt id="spin_sdk.postgres.Connection"><code class="flex name class">
+<span>class <span class="ident">Connection</span></span>
+<span>(</span><span>connection: <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Connection" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Connection">Connection</a>)</span>
 </code></dt>
 <dd>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">async def open(connection_string: str) -&gt; Connection:
-    &#34;&#34;&#34;
-    Open a connection with a Postgres database.
-    
-    The connection_string is the Postgres URL connection string.
+<pre><code class="python">class Connection:
+    def __init__(self, connection: pg.Connection) -&gt; None:
+        self.connection = connection
 
-    A `componentize_py_types.Err(Error_ConnectionFailed(str))` when a connection fails.
-    
-    A `componentize_py_types.Err(Error_Other(str))` when some other error occurs.
-    &#34;&#34;&#34;
-    return await Connection.open_async(connection_string)</code></pre>
+    def __enter__(self) -&gt; Self:
+        return self
+
+    def __exit__(self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: TracebackType | None) -&gt; bool | None:
+        return self.connection.__exit__(exc_type, exc_value, traceback)
+
+    @classmethod
+    async def open(cls, connection_string: str) -&gt; Self:
+        &#34;&#34;&#34;
+        Open a connection with a Postgres database.
+
+        The connection_string is the Postgres URL connection string.
+
+        A `componentize_py_types.Err(Error_ConnectionFailed(str))` when a connection fails.
+
+        A `componentize_py_types.Err(Error_Other(str))` when some other error occurs.
+        &#34;&#34;&#34;
+        return cls(await pg.Connection.open_async(connection_string))
+
+    async def query(self, statement: str, params: List[ParameterValue]) -&gt; Tuple[List[Column], StreamReader[List[DbValue]], FutureReader[Result[None, Error]]]:
+        &#34;&#34;&#34;
+        Query the Postgres database.
+
+        Returns a Tuple containing a List of Columns, a List of DbValues encapsulated in an asynchronous iterator (`componentize_py_async_support.streams.StreamReader`),
+        and a future (`componentize_py_async_support.futures.FutureReader`) containing the result of the operation.
+
+        Raises: `componentize_py_types.Err(spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Error)`
+        &#34;&#34;&#34;
+        return await self.connection.query_async(statement, params)
+
+    async def execute(self, statement: str, params: List[ParameterValue]) -&gt; int:
+        &#34;&#34;&#34;
+        Execute command to the database.
+
+        Returns the number of affected rows as an int.
+
+        Raises: `componentize_py_types.Err(spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Error)`
+        &#34;&#34;&#34;
+        return await self.connection.execute_async(statement, params)</code></pre>
 </details>
+<div class="desc"></div>
+<h3>Static methods</h3>
+<dl>
+<dt id="spin_sdk.postgres.Connection.open"><code class="name flex">
+<span>async def <span class="ident">open</span></span>(<span>connection_string: str) ‑> Self</span>
+</code></dt>
+<dd>
 <div class="desc"><p>Open a connection with a Postgres database.</p>
 <p>The connection_string is the Postgres URL connection string.</p>
 <p>A <code>componentize_py_types.Err(Error_ConnectionFailed(str))</code> when a connection fails.</p>
 <p>A <code>componentize_py_types.Err(Error_Other(str))</code> when some other error occurs.</p></div>
 </dd>
 </dl>
-</section>
-<section>
+<h3>Methods</h3>
+<dl>
+<dt id="spin_sdk.postgres.Connection.execute"><code class="name flex">
+<span>async def <span class="ident">execute</span></span>(<span>self,<br>statement: str,<br>params: List[<a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Boolean" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Boolean">ParameterValue_Boolean</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Int8" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Int8">ParameterValue_Int8</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Int16" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Int16">ParameterValue_Int16</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Int32" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Int32">ParameterValue_Int32</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Int64" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Int64">ParameterValue_Int64</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Floating32" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Floating32">ParameterValue_Floating32</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Floating64" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Floating64">ParameterValue_Floating64</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Str" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Str">ParameterValue_Str</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Binary" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Binary">ParameterValue_Binary</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Date" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Date">ParameterValue_Date</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Time" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Time">ParameterValue_Time</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Datetime" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Datetime">ParameterValue_Datetime</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Timestamp" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Timestamp">ParameterValue_Timestamp</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Uuid" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Uuid">ParameterValue_Uuid</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Jsonb" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Jsonb">ParameterValue_Jsonb</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Decimal" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Decimal">ParameterValue_Decimal</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_RangeInt32" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_RangeInt32">ParameterValue_RangeInt32</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_RangeInt64" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_RangeInt64">ParameterValue_RangeInt64</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_RangeDecimal" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_RangeDecimal">ParameterValue_RangeDecimal</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_ArrayInt32" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_ArrayInt32">ParameterValue_ArrayInt32</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_ArrayInt64" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_ArrayInt64">ParameterValue_ArrayInt64</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_ArrayDecimal" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_ArrayDecimal">ParameterValue_ArrayDecimal</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_ArrayStr" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_ArrayStr">ParameterValue_ArrayStr</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Interval" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Interval">ParameterValue_Interval</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_DbNull" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_DbNull">ParameterValue_DbNull</a>]) ‑> int</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def execute(self, statement: str, params: List[ParameterValue]) -&gt; int:
+    &#34;&#34;&#34;
+    Execute command to the database.
+
+    Returns the number of affected rows as an int.
+
+    Raises: `componentize_py_types.Err(spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Error)`
+    &#34;&#34;&#34;
+    return await self.connection.execute_async(statement, params)</code></pre>
+</details>
+<div class="desc"><p>Execute command to the database.</p>
+<p>Returns the number of affected rows as an int.</p>
+<p>Raises: <code>componentize_py_types.Err(<a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Error" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Error">Error</a>)</code></p></div>
+</dd>
+<dt id="spin_sdk.postgres.Connection.query"><code class="name flex">
+<span>async def <span class="ident">query</span></span>(<span>self,<br>statement: str,<br>params: List[<a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Boolean" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Boolean">ParameterValue_Boolean</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Int8" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Int8">ParameterValue_Int8</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Int16" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Int16">ParameterValue_Int16</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Int32" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Int32">ParameterValue_Int32</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Int64" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Int64">ParameterValue_Int64</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Floating32" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Floating32">ParameterValue_Floating32</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Floating64" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Floating64">ParameterValue_Floating64</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Str" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Str">ParameterValue_Str</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Binary" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Binary">ParameterValue_Binary</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Date" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Date">ParameterValue_Date</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Time" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Time">ParameterValue_Time</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Datetime" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Datetime">ParameterValue_Datetime</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Timestamp" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Timestamp">ParameterValue_Timestamp</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Uuid" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Uuid">ParameterValue_Uuid</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Jsonb" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Jsonb">ParameterValue_Jsonb</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Decimal" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Decimal">ParameterValue_Decimal</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_RangeInt32" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_RangeInt32">ParameterValue_RangeInt32</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_RangeInt64" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_RangeInt64">ParameterValue_RangeInt64</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_RangeDecimal" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_RangeDecimal">ParameterValue_RangeDecimal</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_ArrayInt32" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_ArrayInt32">ParameterValue_ArrayInt32</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_ArrayInt64" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_ArrayInt64">ParameterValue_ArrayInt64</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_ArrayDecimal" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_ArrayDecimal">ParameterValue_ArrayDecimal</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_ArrayStr" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_ArrayStr">ParameterValue_ArrayStr</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Interval" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_Interval">ParameterValue_Interval</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_DbNull" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.ParameterValue_DbNull">ParameterValue_DbNull</a>]) ‑> Tuple[List[<a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Column" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Column">Column</a>], componentize_py_async_support.streams.StreamReader[List[<a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Boolean" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Boolean">DbValue_Boolean</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Int8" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Int8">DbValue_Int8</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Int16" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Int16">DbValue_Int16</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Int32" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Int32">DbValue_Int32</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Int64" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Int64">DbValue_Int64</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Floating32" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Floating32">DbValue_Floating32</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Floating64" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Floating64">DbValue_Floating64</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Str" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Str">DbValue_Str</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Binary" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Binary">DbValue_Binary</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Date" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Date">DbValue_Date</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Time" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Time">DbValue_Time</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Datetime" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Datetime">DbValue_Datetime</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Timestamp" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Timestamp">DbValue_Timestamp</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Uuid" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Uuid">DbValue_Uuid</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Jsonb" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Jsonb">DbValue_Jsonb</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Decimal" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Decimal">DbValue_Decimal</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_RangeInt32" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_RangeInt32">DbValue_RangeInt32</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_RangeInt64" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_RangeInt64">DbValue_RangeInt64</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_RangeDecimal" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_RangeDecimal">DbValue_RangeDecimal</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_ArrayInt32" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_ArrayInt32">DbValue_ArrayInt32</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_ArrayInt64" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_ArrayInt64">DbValue_ArrayInt64</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_ArrayDecimal" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_ArrayDecimal">DbValue_ArrayDecimal</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_ArrayStr" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_ArrayStr">DbValue_ArrayStr</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Interval" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Interval">DbValue_Interval</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_DbNull" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_DbNull">DbValue_DbNull</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Unsupported" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.DbValue_Unsupported">DbValue_Unsupported</a>]], componentize_py_async_support.futures.FutureReader[componentize_py_types.Ok[None] | componentize_py_types.Err[<a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Error_ConnectionFailed" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Error_ConnectionFailed">Error_ConnectionFailed</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Error_BadParameter" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Error_BadParameter">Error_BadParameter</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Error_QueryFailed" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Error_QueryFailed">Error_QueryFailed</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Error_ValueConversionFailed" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Error_ValueConversionFailed">Error_ValueConversionFailed</a> | <a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Error_Other" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Error_Other">Error_Other</a>]]]</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def query(self, statement: str, params: List[ParameterValue]) -&gt; Tuple[List[Column], StreamReader[List[DbValue]], FutureReader[Result[None, Error]]]:
+    &#34;&#34;&#34;
+    Query the Postgres database.
+
+    Returns a Tuple containing a List of Columns, a List of DbValues encapsulated in an asynchronous iterator (`componentize_py_async_support.streams.StreamReader`),
+    and a future (`componentize_py_async_support.futures.FutureReader`) containing the result of the operation.
+
+    Raises: `componentize_py_types.Err(spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Error)`
+    &#34;&#34;&#34;
+    return await self.connection.query_async(statement, params)</code></pre>
+</details>
+<div class="desc"><p>Query the Postgres database.</p>
+<p>Returns a Tuple containing a List of Columns, a List of DbValues encapsulated in an asynchronous iterator (<code>componentize_py_async_support.streams.StreamReader</code>),
+and a future (<code>componentize_py_async_support.futures.FutureReader</code>) containing the result of the operation.</p>
+<p>Raises: <code>componentize_py_types.Err(<a title="spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Error" href="wit/imports/spin_postgres_postgres_4_2_0.html#spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Error">Error</a>)</code></p></div>
+</dd>
+</dl>
+</dd>
+</dl>
 </section>
 </article>
 <nav id="sidebar">
@@ -85,9 +176,16 @@ el.replaceWith(d);
 <li><code><a title="spin_sdk" href="index.html">spin_sdk</a></code></li>
 </ul>
 </li>
-<li><h3><a href="#header-functions">Functions</a></h3>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="spin_sdk.postgres.Connection" href="#spin_sdk.postgres.Connection">Connection</a></code></h4>
 <ul class="">
-<li><code><a title="spin_sdk.postgres.open" href="#spin_sdk.postgres.open">open</a></code></li>
+<li><code><a title="spin_sdk.postgres.Connection.execute" href="#spin_sdk.postgres.Connection.execute">execute</a></code></li>
+<li><code><a title="spin_sdk.postgres.Connection.open" href="#spin_sdk.postgres.Connection.open">open</a></code></li>
+<li><code><a title="spin_sdk.postgres.Connection.query" href="#spin_sdk.postgres.Connection.query">query</a></code></li>
+</ul>
+</li>
 </ul>
 </li>
 </ul>

--- a/docs/v4/sqlite.html
+++ b/docs/v4/sqlite.html
@@ -43,31 +43,87 @@ el.replaceWith(d);
 <section>
 </section>
 <section>
-<h2 class="section-title" id="header-functions">Functions</h2>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
 <dl>
-<dt id="spin_sdk.sqlite.open"><code class="name flex">
-<span>async def <span class="ident">open</span></span>(<span>name: str) ‑> <a title="spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Connection" href="wit/imports/spin_sqlite_sqlite_3_1_0.html#spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Connection">Connection</a></span>
+<dt id="spin_sdk.sqlite.Connection"><code class="flex name class">
+<span>class <span class="ident">Connection</span></span>
+<span>(</span><span>connection: <a title="spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Connection" href="wit/imports/spin_sqlite_sqlite_3_1_0.html#spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Connection">Connection</a>)</span>
 </code></dt>
 <dd>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">async def open(name: str) -&gt; Connection:
-    &#34;&#34;&#34;Open a connection to a named database instance.
+<pre><code class="python">class Connection:
+    def __init__(self, connection: sqlite.Connection) -&gt; None:
+        self.connection = connection
 
-    If `database` is &#34;default&#34;, the default instance is opened.
+    def __enter__(self) -&gt; Self:
+        return self
 
-    A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_AccessDenied)` will be raised when the component does not have access to the specified database.
+    def __exit__(self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: TracebackType | None) -&gt; bool | None:
+        return self.connection.__exit__(exc_type, exc_value, traceback)
 
-    A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_NoSuchDatabase)` will be raised when the host does not recognize the database name requested.
-    
-    A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_InvalidConnection)` will be raised when the provided connection string is not valid.
-    
-    A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_Io(str))` will be raised when implementation-specific error occured (e.g. I/O)
-    &#34;&#34;&#34;
-    return await Connection.open_async(name)</code></pre>
+    @classmethod
+    async def open(cls, name: str) -&gt; Self:
+        &#34;&#34;&#34;Open a connection to a named database instance.
+
+        If `database` is &#34;default&#34;, the default instance is opened.
+
+        A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_AccessDenied)` will be raised when the component does not have access to the specified database.
+
+        A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_NoSuchDatabase)` will be raised when the host does not recognize the database name requested.
+
+        A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_InvalidConnection)` will be raised when the provided connection string is not valid.
+
+        A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_Io(str))` will be raised when implementation-specific error occured (e.g. I/O)
+        &#34;&#34;&#34;
+        return cls(await sqlite.Connection.open_async(name))
+
+    @classmethod
+    async def open_default(cls) -&gt; Self:
+        &#34;&#34;&#34;Open the default store.
+
+        A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_AccessDenied)` will be raised when the component does not have access to the default database.
+
+        A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_Io(str))` will be raised when implementation-specific error occured (e.g. I/O)
+        &#34;&#34;&#34;
+        return cls(await sqlite.Connection.open_async(&#34;default&#34;))
+
+    async def execute(self, statement: str, params: List[Value]) -&gt; Tuple[List[str], StreamReader[RowResult], FutureReader[Result[None, Error]]]:
+        &#34;&#34;&#34;
+        Execute a command to the database.
+
+        Returns a Tuple containing a List of columns, a List of RowResults encapsulated in an asynchronous iterator (`componentize_py_async_support.streams.StreamReader`),
+        and a future (`componentize_py_async_support.futures.FutureReader`) containing the result of the operation.
+
+        Raises: `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error)`
+        &#34;&#34;&#34;
+        return await self.connection.execute_async(statement, params)
+
+    async def last_insert_rowid(self) -&gt; int:
+        &#34;&#34;&#34;
+        The SQLite rowid of the most recent successful INSERT on the connection, or 0 if
+        there has not yet been an INSERT on the connection.
+        &#34;&#34;&#34;
+        return await self.connection.last_insert_rowid_async()
+
+    async def changes(self) -&gt; int:
+        &#34;&#34;&#34;
+        The number of rows modified, inserted or deleted by the most recently completed
+        INSERT, UPDATE or DELETE statement on the connection.
+        &#34;&#34;&#34;
+        return await self.connection.changes_async()</code></pre>
 </details>
+<div class="desc"></div>
+<h3>Static methods</h3>
+<dl>
+<dt id="spin_sdk.sqlite.Connection.open"><code class="name flex">
+<span>async def <span class="ident">open</span></span>(<span>name: str) ‑> Self</span>
+</code></dt>
+<dd>
 <div class="desc"><p>Open a connection to a named database instance.</p>
 <p>If <code>database</code> is "default", the default instance is opened.</p>
 <p>A <code>componentize_py_types.Err(<a title="spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_AccessDenied" href="wit/imports/spin_sqlite_sqlite_3_1_0.html#spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_AccessDenied">Error_AccessDenied</a>)</code> will be raised when the component does not have access to the specified database.</p>
@@ -75,30 +131,80 @@ el.replaceWith(d);
 <p>A <code>componentize_py_types.Err(<a title="spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_InvalidConnection" href="wit/imports/spin_sqlite_sqlite_3_1_0.html#spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_InvalidConnection">Error_InvalidConnection</a>)</code> will be raised when the provided connection string is not valid.</p>
 <p>A <code>componentize_py_types.Err(<a title="spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_Io" href="wit/imports/spin_sqlite_sqlite_3_1_0.html#spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_Io">Error_Io</a>(str))</code> will be raised when implementation-specific error occured (e.g. I/O)</p></div>
 </dd>
-<dt id="spin_sdk.sqlite.open_default"><code class="name flex">
-<span>async def <span class="ident">open_default</span></span>(<span>) ‑> <a title="spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Connection" href="wit/imports/spin_sqlite_sqlite_3_1_0.html#spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Connection">Connection</a></span>
+<dt id="spin_sdk.sqlite.Connection.open_default"><code class="name flex">
+<span>async def <span class="ident">open_default</span></span>(<span>) ‑> Self</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Open the default store.</p>
+<p>A <code>componentize_py_types.Err(<a title="spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_AccessDenied" href="wit/imports/spin_sqlite_sqlite_3_1_0.html#spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_AccessDenied">Error_AccessDenied</a>)</code> will be raised when the component does not have access to the default database.</p>
+<p>A <code>componentize_py_types.Err(<a title="spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_Io" href="wit/imports/spin_sqlite_sqlite_3_1_0.html#spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_Io">Error_Io</a>(str))</code> will be raised when implementation-specific error occured (e.g. I/O)</p></div>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="spin_sdk.sqlite.Connection.changes"><code class="name flex">
+<span>async def <span class="ident">changes</span></span>(<span>self) ‑> int</span>
 </code></dt>
 <dd>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">async def open_default() -&gt; Connection:
-    &#34;&#34;&#34;Open the default store.
-
-    A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_AccessDenied)` will be raised when the component does not have access to the default database.
-
-    A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_Io(str))` will be raised when implementation-specific error occured (e.g. I/O)
+<pre><code class="python">async def changes(self) -&gt; int:
     &#34;&#34;&#34;
-    return await Connection.open_async(&#34;default&#34;)</code></pre>
+    The number of rows modified, inserted or deleted by the most recently completed
+    INSERT, UPDATE or DELETE statement on the connection.
+    &#34;&#34;&#34;
+    return await self.connection.changes_async()</code></pre>
 </details>
-<div class="desc"><p>Open the default store.</p>
-<p>A <code>componentize_py_types.Err(<a title="spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_AccessDenied" href="wit/imports/spin_sqlite_sqlite_3_1_0.html#spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_AccessDenied">Error_AccessDenied</a>)</code> will be raised when the component does not have access to the default database.</p>
-<p>A <code>componentize_py_types.Err(<a title="spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_Io" href="wit/imports/spin_sqlite_sqlite_3_1_0.html#spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_Io">Error_Io</a>(str))</code> will be raised when implementation-specific error occured (e.g. I/O)</p></div>
+<div class="desc"><p>The number of rows modified, inserted or deleted by the most recently completed
+INSERT, UPDATE or DELETE statement on the connection.</p></div>
+</dd>
+<dt id="spin_sdk.sqlite.Connection.execute"><code class="name flex">
+<span>async def <span class="ident">execute</span></span>(<span>self,<br>statement: str,<br>params: List[<a title="spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Value_Integer" href="wit/imports/spin_sqlite_sqlite_3_1_0.html#spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Value_Integer">Value_Integer</a> | <a title="spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Value_Real" href="wit/imports/spin_sqlite_sqlite_3_1_0.html#spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Value_Real">Value_Real</a> | <a title="spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Value_Text" href="wit/imports/spin_sqlite_sqlite_3_1_0.html#spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Value_Text">Value_Text</a> | <a title="spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Value_Blob" href="wit/imports/spin_sqlite_sqlite_3_1_0.html#spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Value_Blob">Value_Blob</a> | <a title="spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Value_Null" href="wit/imports/spin_sqlite_sqlite_3_1_0.html#spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Value_Null">Value_Null</a>]) ‑> Tuple[List[str], componentize_py_async_support.streams.StreamReader[<a title="spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.RowResult" href="wit/imports/spin_sqlite_sqlite_3_1_0.html#spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.RowResult">RowResult</a>], componentize_py_async_support.futures.FutureReader[componentize_py_types.Ok[None] | componentize_py_types.Err[<a title="spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_NoSuchDatabase" href="wit/imports/spin_sqlite_sqlite_3_1_0.html#spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_NoSuchDatabase">Error_NoSuchDatabase</a> | <a title="spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_AccessDenied" href="wit/imports/spin_sqlite_sqlite_3_1_0.html#spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_AccessDenied">Error_AccessDenied</a> | <a title="spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_InvalidConnection" href="wit/imports/spin_sqlite_sqlite_3_1_0.html#spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_InvalidConnection">Error_InvalidConnection</a> | <a title="spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_DatabaseFull" href="wit/imports/spin_sqlite_sqlite_3_1_0.html#spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_DatabaseFull">Error_DatabaseFull</a> | <a title="spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_Io" href="wit/imports/spin_sqlite_sqlite_3_1_0.html#spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_Io">Error_Io</a>]]]</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def execute(self, statement: str, params: List[Value]) -&gt; Tuple[List[str], StreamReader[RowResult], FutureReader[Result[None, Error]]]:
+    &#34;&#34;&#34;
+    Execute a command to the database.
+
+    Returns a Tuple containing a List of columns, a List of RowResults encapsulated in an asynchronous iterator (`componentize_py_async_support.streams.StreamReader`),
+    and a future (`componentize_py_async_support.futures.FutureReader`) containing the result of the operation.
+
+    Raises: `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error)`
+    &#34;&#34;&#34;
+    return await self.connection.execute_async(statement, params)</code></pre>
+</details>
+<div class="desc"><p>Execute a command to the database.</p>
+<p>Returns a Tuple containing a List of columns, a List of RowResults encapsulated in an asynchronous iterator (<code>componentize_py_async_support.streams.StreamReader</code>),
+and a future (<code>componentize_py_async_support.futures.FutureReader</code>) containing the result of the operation.</p>
+<p>Raises: <code>componentize_py_types.Err(<a title="spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error" href="wit/imports/spin_sqlite_sqlite_3_1_0.html#spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error">Error</a>)</code></p></div>
+</dd>
+<dt id="spin_sdk.sqlite.Connection.last_insert_rowid"><code class="name flex">
+<span>async def <span class="ident">last_insert_rowid</span></span>(<span>self) ‑> int</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def last_insert_rowid(self) -&gt; int:
+    &#34;&#34;&#34;
+    The SQLite rowid of the most recent successful INSERT on the connection, or 0 if
+    there has not yet been an INSERT on the connection.
+    &#34;&#34;&#34;
+    return await self.connection.last_insert_rowid_async()</code></pre>
+</details>
+<div class="desc"><p>The SQLite rowid of the most recent successful INSERT on the connection, or 0 if
+there has not yet been an INSERT on the connection.</p></div>
 </dd>
 </dl>
-</section>
-<section>
+</dd>
+</dl>
 </section>
 </article>
 <nav id="sidebar">
@@ -111,10 +217,18 @@ el.replaceWith(d);
 <li><code><a title="spin_sdk" href="index.html">spin_sdk</a></code></li>
 </ul>
 </li>
-<li><h3><a href="#header-functions">Functions</a></h3>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="spin_sdk.sqlite.Connection" href="#spin_sdk.sqlite.Connection">Connection</a></code></h4>
 <ul class="">
-<li><code><a title="spin_sdk.sqlite.open" href="#spin_sdk.sqlite.open">open</a></code></li>
-<li><code><a title="spin_sdk.sqlite.open_default" href="#spin_sdk.sqlite.open_default">open_default</a></code></li>
+<li><code><a title="spin_sdk.sqlite.Connection.changes" href="#spin_sdk.sqlite.Connection.changes">changes</a></code></li>
+<li><code><a title="spin_sdk.sqlite.Connection.execute" href="#spin_sdk.sqlite.Connection.execute">execute</a></code></li>
+<li><code><a title="spin_sdk.sqlite.Connection.last_insert_rowid" href="#spin_sdk.sqlite.Connection.last_insert_rowid">last_insert_rowid</a></code></li>
+<li><code><a title="spin_sdk.sqlite.Connection.open" href="#spin_sdk.sqlite.Connection.open">open</a></code></li>
+<li><code><a title="spin_sdk.sqlite.Connection.open_default" href="#spin_sdk.sqlite.Connection.open_default">open_default</a></code></li>
+</ul>
+</li>
 </ul>
 </li>
 </ul>

--- a/examples/spin-postgres/app.py
+++ b/examples/spin-postgres/app.py
@@ -1,13 +1,11 @@
-from spin_sdk import http, postgres
+from spin_sdk import http, postgres, util
 from spin_sdk.http import Request, Response
-from spin_sdk.postgres import RowSet, DbValue
-
+from spin_sdk.postgres import Connection, RowSet, DbValue
 
 def format_value(db_value: DbValue) -> str:
     if hasattr(db_value, "value"):
         return str(db_value.value)
     return "NULL"
-
 
 def format_rowset(rowset: RowSet) -> str:
     lines = []
@@ -19,11 +17,12 @@ def format_rowset(rowset: RowSet) -> str:
         lines.append(" | ".join(values))
     return "\n".join(lines)
 
-
 class HttpHandler(http.Handler):
     async def handle_request(self, request: Request) -> Response:
-        with await postgres.open("user=postgres dbname=spin_dev host=localhost sslmode=disable password=password") as db:
-            rowset = db.query("SELECT * FROM test", [])
+        with await Connection.open("user=postgres dbname=spin_dev host=localhost sslmode=disable password=password") as db:
+            columns, stream, future = await db.query("SELECT * FROM test", [])
+            rows = await util.collect((stream, future))
+            rowset = RowSet(columns, list(rows))
             result = format_rowset(rowset)
 
         return Response(200, {"content-type": "text/plain"}, bytes(result, "utf-8"))

--- a/examples/spin-sqlite/app.py
+++ b/examples/spin-sqlite/app.py
@@ -1,13 +1,35 @@
-from spin_sdk import http, sqlite
+from spin_sdk import http
 from spin_sdk.http import Request, Response
-from spin_sdk.sqlite import Value_Integer
+from spin_sdk.sqlite import Connection, Value_Text, Value_Integer
+from spin_sdk.util import collect
 
 class HttpHandler(http.Handler):
     async def handle_request(self, request: Request) -> Response:
-        with await sqlite.open_default() as db:
-            result = db.execute("SELECT * FROM todos WHERE id > (?);", [Value_Integer(1)])
-            rows = result.rows
-        
+        with await Connection.open_default() as db:
+            _, stream, result = await db.execute(
+                "CREATE TABLE IF NOT EXISTS example (id INTEGER NOT NULL PRIMARY KEY, value TEXT NOT NULL)",
+                []
+            )
+            await collect((stream, result))
+
+            insert = "INSERT INTO example (id, value) VALUES (?, ?) ON CONFLICT (id) DO UPDATE SET value=excluded.value"
+
+            _, stream, result = await db.execute(insert, [Value_Integer(1), Value_Text("foo")])
+            await collect((stream, result))
+            
+            _, stream, result = await db.execute(insert, [Value_Integer(2), Value_Text("bar")])
+            await collect((stream, result))
+            
+            columns, stream, result = await db.execute("SELECT * FROM example WHERE id > (?);", [Value_Integer(0)])
+            rows = await collect((stream, result))
+
+            assert columns == ["id", "value"]
+            assert len(rows) == 1
+            assert isinstance(rows[0].values[0], Value_Integer)
+            assert rows[0].values[0].value == 2
+            assert isinstance(rows[0].values[1], Value_Text)
+            assert rows[0].values[1].value == "bar"
+
         return Response(
             200,
             {"content-type": "text/plain"},

--- a/src/spin_sdk/postgres.py
+++ b/src/spin_sdk/postgres.py
@@ -1,19 +1,58 @@
 """Module for interacting with a Postgres database"""
 
+from typing import List, Tuple, Self
+from types import TracebackType
+from componentize_py_types import Result
+from componentize_py_async_support.streams import StreamReader
+from componentize_py_async_support.futures import FutureReader
 from spin_sdk.wit.imports import spin_postgres_postgres_4_2_0 as pg
 
-Connection = pg.Connection
 RowSet = pg.RowSet
 DbValue = pg.DbValue
+ParameterValue = pg.ParameterValue
+Column = pg.Column
+Error  = pg.Error
 
-async def open(connection_string: str) -> Connection:
-    """
-    Open a connection with a Postgres database.
-    
-    The connection_string is the Postgres URL connection string.
+class Connection:
+    def __init__(self, connection: pg.Connection) -> None:
+        self.connection = connection
 
-    A `componentize_py_types.Err(Error_ConnectionFailed(str))` when a connection fails.
-    
-    A `componentize_py_types.Err(Error_Other(str))` when some other error occurs.
-    """
-    return await Connection.open_async(connection_string)
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: TracebackType | None) -> bool | None:
+        return self.connection.__exit__(exc_type, exc_value, traceback)
+
+    @classmethod
+    async def open(cls, connection_string: str) -> Self:
+        """
+        Open a connection with a Postgres database.
+
+        The connection_string is the Postgres URL or connection string.
+
+        A `componentize_py_types.Err(Error_ConnectionFailed(str))` when a connection fails.
+
+        A `componentize_py_types.Err(Error_Other(str))` when some other error occurs.
+        """
+        return cls(await pg.Connection.open_async(connection_string))
+
+    async def query(self, statement: str, params: List[ParameterValue]) -> Tuple[List[Column], StreamReader[List[DbValue]], FutureReader[Result[None, Error]]]:
+        """
+        Query the Postgres database.
+
+        Returns a Tuple containing a List of Columns, a List of DbValues encapsulated in an asynchronous iterator (`componentize_py_async_support.streams.StreamReader`),
+        and a future (`componentize_py_async_support.futures.FutureReader`) containing the result of the operation.
+
+        Raises: `componentize_py_types.Err(spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Error)`
+        """
+        return await self.connection.query_async(statement, params)
+
+    async def execute(self, statement: str, params: List[ParameterValue]) -> int:
+        """
+        Execute command to the database.
+
+        Returns the number of affected rows as an int.
+
+        Raises: `componentize_py_types.Err(spin_sdk.wit.imports.spin_postgres_postgres_4_2_0.Error)`
+        """
+        return await self.connection.execute_async(statement, params)

--- a/src/spin_sdk/sqlite.py
+++ b/src/spin_sdk/sqlite.py
@@ -1,34 +1,77 @@
 """Module for interacting with an SQLite database"""
 
-from typing import List
+from typing import List, Tuple, Self
+from types import TracebackType
+from componentize_py_types import Result
+from componentize_py_async_support.streams import StreamReader
+from componentize_py_async_support.futures import FutureReader
 from spin_sdk.wit.imports import spin_sqlite_sqlite_3_1_0 as sqlite
 
-Connection = sqlite.Connection
+Error = sqlite.Error
+Value = sqlite.Value
 Value_Integer = sqlite.Value_Integer
 Value_Real = sqlite.Value_Real
 Value_Text = sqlite.Value_Text
 Value_Blob = sqlite.Value_Blob
+RowResult = sqlite.RowResult
 
-async def open(name: str) -> Connection:
-    """Open a connection to a named database instance.
+class Connection:
+    def __init__(self, connection: sqlite.Connection) -> None:
+        self.connection = connection
 
-    If `database` is "default", the default instance is opened.
+    def __enter__(self) -> Self:
+        return self
 
-    A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_AccessDenied)` will be raised when the component does not have access to the specified database.
+    def __exit__(self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: TracebackType | None) -> bool | None:
+        return self.connection.__exit__(exc_type, exc_value, traceback)
 
-    A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_NoSuchDatabase)` will be raised when the host does not recognize the database name requested.
-    
-    A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_InvalidConnection)` will be raised when the provided connection string is not valid.
-    
-    A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_Io(str))` will be raised when implementation-specific error occured (e.g. I/O)
-    """
-    return await Connection.open_async(name)
+    @classmethod
+    async def open(cls, name: str) -> Self:
+        """Open a connection to a named database instance.
 
-async def open_default() -> Connection:
-    """Open the default store.
+        If `database` is "default", the default instance is opened.
 
-    A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_AccessDenied)` will be raised when the component does not have access to the default database.
+        A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_AccessDenied)` will be raised when the component does not have access to the specified database.
 
-    A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_Io(str))` will be raised when implementation-specific error occured (e.g. I/O)
-    """
-    return await Connection.open_async("default")
+        A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_NoSuchDatabase)` will be raised when the host does not recognize the database name requested.
+
+        A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_InvalidConnection)` will be raised when the provided connection string is not valid.
+
+        A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_Io(str))` will be raised when implementation-specific error occured (e.g. I/O)
+        """
+        return cls(await sqlite.Connection.open_async(name))
+
+    @classmethod
+    async def open_default(cls) -> Self:
+        """Open the default store.
+
+        A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_AccessDenied)` will be raised when the component does not have access to the default database.
+
+        A `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error_Io(str))` will be raised when implementation-specific error occured (e.g. I/O)
+        """
+        return cls(await sqlite.Connection.open_async("default"))
+
+    async def execute(self, statement: str, params: List[Value]) -> Tuple[List[str], StreamReader[RowResult], FutureReader[Result[None, Error]]]:
+        """
+        Execute a command to the database.
+
+        Returns a Tuple containing a List of columns, a List of RowResults encapsulated in an asynchronous iterator (`componentize_py_async_support.streams.StreamReader`),
+        and a future (`componentize_py_async_support.futures.FutureReader`) containing the result of the operation.
+
+        Raises: `componentize_py_types.Err(spin_sdk.wit.imports.spin_sqlite_sqlite_3_1_0.Error)`
+        """
+        return await self.connection.execute_async(statement, params)
+
+    async def last_insert_rowid(self) -> int:
+        """
+        The SQLite rowid of the most recent successful INSERT on the connection, or 0 if
+        there has not yet been an INSERT on the connection.
+        """
+        return await self.connection.last_insert_rowid_async()
+
+    async def changes(self) -> int:
+        """
+        The number of rows modified, inserted or deleted by the most recently completed
+        INSERT, UPDATE or DELETE statement on the connection.
+        """
+        return await self.connection.changes_async()


### PR DESCRIPTION
Updates the postgres and sqlite modules to provide a completely async, opinionated API.  This breaks the previous (canary) versions of the v4 SDKs but as they hadn't yet been released, this seems a good time to do it.

TODO:
- [x] regenerate docs
- [ ] update docs on spinframework.dev -> https://github.com/spinframework/spin-docs/pull/190

Closes https://github.com/spinframework/spin-python-sdk/issues/146