### PR TITLE
bump componentize-py version to v0.23.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           python -m venv venv
           source venv/bin/activate
-          pip install componentize-py==0.22.1 http-router==4.1.2 build==1.4.2 mypy==1.13
+          pip install componentize-py==0.23.0 http-router==4.1.2 build==1.4.2 mypy==1.13
           python -m build
           pip install dist/spin_sdk-4.0.0-py3-none-any.whl
           bash run_tests.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,12 +4,12 @@
 
 - Python
 - `pip`
-- `componentize-py` 0.22.1
+- `componentize-py` 0.23.0
 
 Once you have `pip` installed, you can install `componentize-py` using:
 
 ```bash
-pip install componentize-py==0.22.1
+pip install componentize-py==0.23.0
 ```
 
 ### Generating the bindings

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ enter a virtual environment and then install the desired packages
 ```shell
 python -m venv .venv
 source .venv/bin/activate
-pip install componentize-py==0.22.1 spin-sdk==4.0.0 mypy==1.8.0
+pip install componentize-py==0.23.0 spin-sdk==4.0.0 mypy==1.8.0
 ```
 
 ### Hello, World

--- a/examples/external-lib-example/requirements.txt
+++ b/examples/external-lib-example/requirements.txt
@@ -1,3 +1,3 @@
 spin-sdk == 4.0.0
-componentize-py == 0.22.1
+componentize-py == 0.23.0
 http-router == 4.1.2

--- a/examples/hello/requirements.txt
+++ b/examples/hello/requirements.txt
@@ -1,2 +1,2 @@
 spin-sdk == 4.0.0
-componentize-py == 0.22.1
+componentize-py == 0.23.0

--- a/examples/matrix-math/requirements.txt
+++ b/examples/matrix-math/requirements.txt
@@ -1,2 +1,2 @@
 spin-sdk == 4.0.0
-componentize-py == 0.22.1
+componentize-py == 0.23.0

--- a/examples/outgoing-request/requirements.txt
+++ b/examples/outgoing-request/requirements.txt
@@ -1,2 +1,2 @@
 spin-sdk == 4.0.0
-componentize-py == 0.22.1
+componentize-py == 0.23.0

--- a/examples/redis-trigger/requirements.txt
+++ b/examples/redis-trigger/requirements.txt
@@ -1,2 +1,2 @@
 spin-sdk == 4.0.0
-componentize-py == 0.22.1
+componentize-py == 0.23.0

--- a/examples/spin-kv/requirements.txt
+++ b/examples/spin-kv/requirements.txt
@@ -1,2 +1,2 @@
 spin-sdk == 4.0.0
-componentize-py == 0.22.1
+componentize-py == 0.23.0

--- a/examples/spin-llm/requirements.txt
+++ b/examples/spin-llm/requirements.txt
@@ -1,2 +1,2 @@
 spin-sdk == 4.0.0
-componentize-py == 0.22.1
+componentize-py == 0.23.0

--- a/examples/spin-mysql/requirements.txt
+++ b/examples/spin-mysql/requirements.txt
@@ -1,2 +1,2 @@
 spin-sdk == 4.0.0
-componentize-py == 0.22.1
+componentize-py == 0.23.0

--- a/examples/spin-outbound-mqtt/requirements.txt
+++ b/examples/spin-outbound-mqtt/requirements.txt
@@ -1,2 +1,2 @@
 spin-sdk == 4.0.0
-componentize-py == 0.22.1
+componentize-py == 0.23.0

--- a/examples/spin-outbound-mqtt/spin.toml
+++ b/examples/spin-outbound-mqtt/spin.toml
@@ -14,4 +14,4 @@ component = "test"
 source = "app.wasm"
 allowed_outbound_hosts = ["*://*:*"]
 [component.test.build]
-command = "componentize-py -d ../../src/spin_sdk/wit -w spin:up/http-trigger@4.0.0 componentize app -o app.wasm"
+command = "componentize-py -w spin:up/http-trigger@4.0.0 componentize app -o app.wasm"

--- a/examples/spin-postgres/requirements.txt
+++ b/examples/spin-postgres/requirements.txt
@@ -1,2 +1,2 @@
 spin-sdk == 4.0.0
-componentize-py == 0.22.1
+componentize-py == 0.23.0

--- a/examples/spin-redis/requirements.txt
+++ b/examples/spin-redis/requirements.txt
@@ -1,2 +1,2 @@
 spin-sdk == 4.0.0
-componentize-py == 0.22.1
+componentize-py == 0.23.0

--- a/examples/spin-sqlite/requirements.txt
+++ b/examples/spin-sqlite/requirements.txt
@@ -1,2 +1,2 @@
 spin-sdk == 4.0.0
-componentize-py == 0.22.1
+componentize-py == 0.23.0

--- a/examples/spin-variables/requirements.txt
+++ b/examples/spin-variables/requirements.txt
@@ -1,2 +1,2 @@
 spin-sdk == 4.0.0
-componentize-py == 0.22.1
+componentize-py == 0.23.0

--- a/examples/streaming/requirements.txt
+++ b/examples/streaming/requirements.txt
@@ -1,2 +1,2 @@
 spin-sdk == 4.0.0
-componentize-py == 0.22.1
+componentize-py == 0.23.0

--- a/templates/http-py/content/requirements.txt
+++ b/templates/http-py/content/requirements.txt
@@ -1,2 +1,2 @@
 spin-sdk == 4.0.0
-componentize-py == 0.22.1
+componentize-py == 0.23.0


### PR DESCRIPTION
Also, remove redundant wit path option from `mqtt` example `spin.toml` file.